### PR TITLE
Modified to run 'cd scripts/' due to pwd resetting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,5 @@ jobs:
       run: cd ..
     - name: chmod shell files
       run: chmod +x scripts/*.sh
-    - name: cd to scripts
-      run: cd scripts/
-    - name: pwd for debug
-      run: pwd
-    - name: configure
-      run: ./config.sh
+    - name: configure if config.sh exists
+      run: cd scripts/ && ./config.sh


### PR DESCRIPTION
Apparently GitHub or Git runs individual shell scripts (these don't retain the current directory) so I made it run 'cd scripts/' each time (1 time because only ./configure is run).