### PR TITLE
Makefile: Fix C_SOURCES

### DIFF
--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -12,7 +12,7 @@ CFLAGS = -Wno-attributes -Wno-discarded-qualifiers -Wno-int-conversion -ffreesta
 ASFLAGS = -f elf32
 LDFLAGS = -T./kernel/arch/$(ARCH)/link.ld -ffreestanding -O2 -nostdlib
 
-C_SOURCES = $(shell find init/ initrd/ kernel/ lib/ user/ -name '*.c')
+C_SOURCES = $(shell find kernel/ lib/ user/ -name '*.c')
 ASM_SOURCES = $(shell find kernel/ -name '*.asm')
 OBJ_FILES = $(C_SOURCES:.c=.o) $(ASM_SOURCES:.asm=.o)
 INITRD_FILES = kernel/initrd/file.txt file.txt kernel/initrd/file2.txt file2.txt


### PR DESCRIPTION
Running `make clean` gives the following warnings:
	- find: init/ not found
	- find: initrd/ not found

Fix the warnings by removing init/ and initrd/ from `C_SOURCES` in
`scripts/Makefile.build`.
